### PR TITLE
🛍️ Fetch User Order History and Display in Frontend

### DIFF
--- a/Frontend/src/Component/User/OrderHistory/Orderhistory.jsx
+++ b/Frontend/src/Component/User/OrderHistory/Orderhistory.jsx
@@ -1,133 +1,63 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Package } from "lucide-react";
 import Sidebar from "../Sidebar";
-
-// const staticOrders = [
-//   {
-//     id: '199',
-//     status: 'pending',
-//     items: 12,
-//     submitDate: '2025-01-10',
-//     roomNumber: '17',
-//     name: 'kashyap',
-//     weight: 4,
-//   },
-//   {
-//     id: '',
-//     status: 'pending',
-//     items: 0,
-//     submitDate: '2025-01-10',
-//     roomNumber: '',
-//     name: '',
-//     weight: 0,
-//   },
-//   {
-//     id: '',
-//     status: 'pending',
-//     items: 0,
-//     submitDate: '2025-01-10',
-//     roomNumber: '',
-//     name: '',
-//     weight: 0,
-//   }
-// ];
-
-// const OrderHistory = () => {
-//   return (
-//     <div className="max-w-3xl mx-auto p-6">
-//       <h1 className="text-3xl font-bold text-gray-900 mb-4">Order History</h1>
-
-//       {/* Recent Orders Section */}
-//       <div className="bg-gray-100 p-4 rounded-lg">
-//         <h2 className="text-lg font-semibold">Recent Orders</h2>
-//         <p className="text-gray-500 text-sm">View your past laundry orders</p>
-//       </div>
-
-//       {/* Order List */}
-//       <div className="space-y-3 mt-4">
-//         {staticOrders.map((order, index) => (
-//           <div key={index} className="bg-white rounded-lg shadow-sm p-4 flex justify-between items-center">
-//             {/* Left Side - Order Details */}
-//             <div className="flex items-center space-x-3">
-//               <Package className="text-blue-500" />
-//               <div>
-//                 <p className="font-medium text-gray-800">
-//                   Order #{order.id ? order.id : ''}
-//                 </p>
-//                 {order.name && (
-//                   <p className="text-sm text-gray-500">
-//                     {order.name} - Room {order.roomNumber}
-//                   </p>
-//                 )}
-//                 <p className="text-sm text-gray-500">
-//                   {order.items} items • {order.weight}kg
-//                 </p>
-//               </div>
-//             </div>
-
-//             {/* Right Side - Status & Date */}
-//             <div className="text-right">
-//               <p className="font-medium text-yellow-600 capitalize">
-//                 {order.status}
-//               </p>
-//               <p className="text-xs text-gray-500">{order.submitDate}</p>
-//             </div>
-//           </div>
-//         ))}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default OrderHistory;
-
+import axios from 'axios'
+import { OrderContext } from "../SubmitOrder/OrderContext";
+import { useContext } from "react";
+import LoaderM from "../../../assets/loader/loader";
 export default function Orderhistory() {
-  const orders = [
-    {
-      id: 199,
-      name: "Mayur",
-      room: "Room 52",
-      items: 12,
-      weight: "4kg",
-      status: "Pending",
-      date: "1/10/2025",
-    },
-    {
-      id: null,
-      name: "jagjeet",
-      room: "Room 29",
-      items: 0,
-      weight: "0kg",
-      status: "Completed",
-      date: "1/10/2025",
-    },
-    {
-      id: null,
-      name: "",
-      room: "Room",
-      items: 0,
-      weight: "3kg",
-      status: "Completed",
-      date: "1/10/2025",
-    },
-  ];
+  
+  const[orders,setOrders]=useState([]);
+  const[loading,setLoading]=useState(false)
+
+
+  const{bagNumber,roomNumber} = useContext(OrderContext);
+
+  useEffect(() => {
+    setLoading(true);
+     const fetchUserHistory = async () =>{
+    try{
+       
+      const token = localStorage.getItem("token");
+
+      const response = await axios.get("http://localhost:3000/user/order-history",{
+        headers: { Authorization: `Bearer ${token}` }
+      })
+
+      const data = await response.data;
+      setOrders(data.order)
+ 
+
+    }catch(error){
+      console.error(error.response?.data?.message || error.message)
+    }finally{
+      setLoading(false)
+    }
+     }
+     fetchUserHistory();
+  },[]);
 
   return (
     <div>
     <div>
         <Sidebar />
     </div>
-    <div className="max-w-3xl mx-auto p-6">
+    {loading ? (
+      <div className="fixed inset-0 flex items-center justify-center bg-gray-100 ">     
+      <LoaderM />
+</div>
+    ):(
+      <div className="max-w-3xl mx-auto p-6">
       <h1 className="text-2xl font-bold text-gray-900 mb-4">Order History</h1>
-      {/* <p className="text-gray-500">View your past laundry orders</p> */}
+      <p className="text-gray-500">View your past laundry orders</p>
       <div className="bg-white shadow-md rounded-lg p-4 mt-4 ">
         <div className=" p-4 rounded-lg border-b">
           <h2 className="text-lg font-semibold">Recent Orders</h2>
           <p className="text-gray-500 text-sm">View your past laundry orders</p>
         </div>
-        {orders.map((order, index) => (
+        {orders.map((order) => (
           <div
-            key={index}
+            key={order.orderId}
             className="border-b last:border-none py-4 flex justify-between items-center"
           >
             <div className="flex gap-4">
@@ -136,13 +66,13 @@ export default function Orderhistory() {
               </div>
               <div>
                 <h3 className="font-semibold">
-                  Order #{order.id ? order.id : ""}
+                  Order No. {bagNumber}
                 </h3>
                 <p className="text-gray-600">
-                 {order.name} -  {order.room}
+                 {order.name} - Room {roomNumber}
                 </p>
                 <p className="text-gray-500">
-                  {order.items} items • {order.weight}
+                  {order.numberOfClothes} items • {order.weight} Kg
                 </p>
               </div>
             </div>
@@ -154,12 +84,14 @@ export default function Orderhistory() {
               }`}>
               {order.status}
               </p>
-              <p className="text-gray-400 text-sm">{order.date}</p>
+              <p className="text-gray-400 text-sm">{order.createdAt}</p>
             </div>
           </div>
         ))}
       </div>
     </div>
-    </div>
+
+    )}
+        </div>
   );
 }

--- a/Frontend/src/Component/User/SubmitOrder/OrderContext.jsx
+++ b/Frontend/src/Component/User/SubmitOrder/OrderContext.jsx
@@ -6,9 +6,10 @@ export const OrderProvider = ({children}) => {
     const[weight,setWeight]=useState("");
     const[numberofitems,setNumberOfItems]=useState("");
     const[bagNumber,setBagNumber]=useState("");
+    const[roomNumber,setRoomNumber]=useState("");
 
     return (
-        <OrderContext.Provider value={{weight,setWeight,numberofitems,setNumberOfItems,bagNumber,setBagNumber}}>
+        <OrderContext.Provider value={{weight,setWeight,numberofitems,setNumberOfItems,bagNumber,setBagNumber,roomNumber,setRoomNumber}}>
             {children}
         </OrderContext.Provider>
     )

--- a/Frontend/src/Component/User/SubmitOrder/Submitorder.jsx
+++ b/Frontend/src/Component/User/SubmitOrder/Submitorder.jsx
@@ -38,7 +38,7 @@ export default function SubmitOrder() {
 
 
   // to send data for orderconfirmation component
-  const {weight,setWeight,numberofitems,setNumberOfItems,bagNumber,setBagNumber}= useContext(OrderContext)
+  const {weight,setWeight,numberofitems,setNumberOfItems,bagNumber,setBagNumber,setRoomNumber}= useContext(OrderContext)
 
 
   // To get the user deatails for submit form 
@@ -63,6 +63,7 @@ export default function SubmitOrder() {
 
         setUser(data)
         setBagNumber(data.bagNumber)
+        setRoomNumber(data.roomNumber)
 
       } catch (error) {
         setError(error.response?.data?.message || error.message)
@@ -141,7 +142,7 @@ export default function SubmitOrder() {
       <Sidebar />
 
       
-    <orderConfirmation />
+    
 
         {/* Main Content */}
         <div className="min-h-screen bg-gray-100 p-6 ml-0 md:ml-96 w-full">


### PR DESCRIPTION


## ✨ Overview  
This PR introduces the functionality to fetch user order history from the backend and display it dynamically using `map` in the frontend. Additionally, the room number has been added for better data representation.  

## 🔥 Changes Implemented  
- ✅ Fetch user order history from the API.  
- ✅ Store total, pending, and completed orders using `useState`.  
- ✅ Display order details dynamically using `map()`.  
- ✅ Added room number for better order identification.  



## 🚀 How to Test  
1. Pull this branch locally.  
2. Run the frontend and backend services.  
3. Log in as a user and navigate to the **Order History** page.  
4. Verify that orders are displayed correctly with proper status and room number.  

## 🛠️ Tech Used  
- React (useState, useEffect)  
- Axios (API calls)  
- Tailwind CSS (Styling)  



### 🔗 Related Issues / PRs  
*(Mention if this PR is linked to any issue or previous PRs)*  


